### PR TITLE
Update make-pkg-and-pkginfo.py

### DIFF
--- a/munki-import-automations/McAfee-Agent/make-pkg-and-pkginfo.py
+++ b/munki-import-automations/McAfee-Agent/make-pkg-and-pkginfo.py
@@ -44,8 +44,6 @@ def generate_dmg(given_app_version,given_vendor_bash_archive):
                                ITEM_MUNKI_NAME,
                                '-fs',
                                'Journaled HFS+',
-                               '-size',
-                               '10m',
                                '-layout',
                                'NONE',
                                sparse_dmg_path])


### PR DESCRIPTION
Found that the later versions of the agent exceeded the 10MB size limit for the Sparse Image.  This argument is not necessary and the tooling works great without it.  Tested on macOS 11.2.3 with McAfee Agent 5.7.1.116.